### PR TITLE
Fix bug that cleaned repos all the time

### DIFF
--- a/src/aliases.cmd
+++ b/src/aliases.cmd
@@ -52,7 +52,7 @@ doskey gcl=git clone --recursive $*
 
 doskey gclean=git clean -fd
 
-doskey gpristine=git reset --hard && git clean -dfx
+doskey gpristine=git reset --hard $T git clean -dfx
 
 doskey gcm=git checkout master
 


### PR DESCRIPTION
`doskey` doesn't allow you to use `&&` for multi-step commands; instead, it's `$T`. Having it as `&&` meant that `git clean -dfx` was getting run automatically every time the `AutoRun` registry key triggers, which it turns out is an awful lot. You'd expect it to only do it on `cmd.exe` startup but no, it does it when running any command-line programs too like npm.

Anyway, this seems to stop it automatically deleting all my uncommited files, which is nice.